### PR TITLE
Update link name to Firefox for Android

### DIFF
--- a/files/en-us/mozilla/developer_guide/introduction/index.html
+++ b/files/en-us/mozilla/developer_guide/introduction/index.html
@@ -57,9 +57,9 @@ tags:
    <td><a href="https://github.com/mozilla-mobile/firefox-tv">Contribute to Firefox for Fire TV</a></td>
   </tr>
   <tr>
-   <td>Firefox Preview (mobile browser, codename: "Fenix")</td>
+   <td>Firefox for Android (mobile browser, codename: "Fenix")</td>
    <td>Kotlin</td>
-   <td><a href="https://github.com/mozilla-mobile/fenix">Contribute to Firefox Preview</a></td>
+   <td><a href="https://github.com/mozilla-mobile/fenix">Contribute to Firefox for Android</a></td>
   </tr>
   <tr>
    <td>Firefox for iOS</td>


### PR DESCRIPTION
Update link name from Firefox Preview to Firefox for Android

<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? Change link name from Firefox Preview to Firefox for Android

> MDN URL of main page changed

> Issue number (if there is an associated issue)

> Anything else that could help us review it
